### PR TITLE
Kg 8 datamodel organisaties review

### DIFF
--- a/ontologies/org.rdfs.ttl
+++ b/ontologies/org.rdfs.ttl
@@ -185,3 +185,15 @@ org:unitOf a owl:ObjectProperty, rdf:Property ;
     skos:definition """Indique l'Organisation dont cette Organisation ou Unité fait partie, par exemple un Départment au sein d'une Organisation Formelle plus large. Inverse de `org:hasUnit`."""@fr ;    
     skos:definition """Duidt de Organisatie aan waarvan deze Organisatie of eenheid deel uitmaakt, bv. een departement binnen een grotere formele Organisatie. Omgekeerde van `org:hasUnit`."""@nl ;
     rdfs:isDefinedBy <http://www.w3.org/ns/org> .
+
+org:role a owl:ObjectProperty, rdf:Property;
+    rdfs:domain org:Post;
+    rdfs:range  org:Role;
+    rdfs:label "role"@en;
+    rdfs:label "rôle"@fr;
+    rdfs:label "ruolo"@it;
+    rdfs:comment """Indicates the Role that the Agent plays in a Membership relationship with an Organization."""@en;
+    rdfs:comment """Indique le Rôle de l'Agent dans son Engagement avec l'Organisation."""@fr;    
+    rdfs:comment """Indica il Role che un Agent ricopre in una relazione di Membership con una Organization"""@it;
+    rdfs:comment "エージェントが組織との構成員関係において担う役割を示します。ポストの保持者が担う役割を示すためにorg:Postで用いることもできます。"@ja;
+    rdfs:isDefinedBy <http://www.w3.org/ns/org> ;

--- a/ontologies/org.rdfs.ttl
+++ b/ontologies/org.rdfs.ttl
@@ -10,6 +10,16 @@
 #              CLASSES              #
 #####################################
 
+org:FormalOrganization a owl:Class, rdfs:Class;
+    rdfs:subClassOf  org:Organization, foaf:Organization;
+    rdfs:label "Formal Organization"@en;
+    rdfs:label "Organisation Formelle"@fr;
+    rdfs:label "Formele Organisatie"@nl;
+    rdfs:comment """An Organization which is recognized in the world at large, in particular in legal jurisdictions, with associated rights and responsibilities. Examples include a Corporation, Charity, Government or Church. Note that this is a super class of `gr:BusinessEntity` and it is recommended to use the GoodRelations vocabulary to denote Business classifications such as DUNS or NAICS."""@en; 
+    rdfs:comment """Une Organisation reconnue, en particulier par les juridictions locales, ayant des droits et des responsabilités. Exemples : entreprises, association à but non-lucratif, collectivité, église. Notez que c'est une super-classe de `gr:BusinessEntity` et qu'il est recommandé d'utiliser le vocabulaire GoodRelations pour indiquer les classifications économiques comme le code NACE."""@fr;     
+    rdfs:comment """Een organisatie dat wordt herkend als een officiele instantie door rechtelijke jurispudentie, met de daarbij behorende verantwoordelijkheden en rechten. Hieronder vallen bijvoorbeeld Bedrijven, liefdadigheidsinstellingen, overheden of kerken. Let op, dit is een superklasse van `gr:BusinessEntity` en het is gebruikelijk om Goodrelations vocabulaire te gebruiken om de klassificatie van de organisatie aan te geven middels DUNS of NAICS."""@it;
+    rdfs:isDefinedBy <http://www.w3.org/ns/org> .
+
 org:Organization    a   owl:Class,  rdfs:Class ;
     rdfs:subClassOf  foaf:Agent ;
     owl:equivalentClass foaf:Organization ;
@@ -163,6 +173,17 @@ org:postIn a owl:ObjectProperty, rdf:Property ;
     skos:definition """Duidt de organisatie aan waarbij de positie bestaat."""@nl ;
     rdfs:isDefinedBy <http://www.w3.org/ns/org> .
 
+org:role a owl:ObjectProperty, rdf:Property;
+    rdfs:domain org:Post;
+    rdfs:range  org:Role;
+    rdfs:label "role"@en;
+    rdfs:label "rôle"@fr;
+    rdfs:label "rol"@nl;
+    rdfs:comment """Indicates the Role that the Agent plays in a Membership relationship with an Organization."""@en;
+    rdfs:comment """Indique le Rôle de l'Agent dans son Engagement avec l'Organisation."""@fr;    
+    rdfs:comment """Duidt de rol aan die een Agent uitvoert in relatie met een organisatie."""@it;
+    rdfs:isDefinedBy <http://www.w3.org/ns/org> .
+
 org:siteAddress a owl:ObjectProperty, rdf:Property ;
     rdfs:domain org:Site ;
     #   rdfs:range  vcard:VCard ;
@@ -185,15 +206,3 @@ org:unitOf a owl:ObjectProperty, rdf:Property ;
     skos:definition """Indique l'Organisation dont cette Organisation ou Unité fait partie, par exemple un Départment au sein d'une Organisation Formelle plus large. Inverse de `org:hasUnit`."""@fr ;    
     skos:definition """Duidt de Organisatie aan waarvan deze Organisatie of eenheid deel uitmaakt, bv. een departement binnen een grotere formele Organisatie. Omgekeerde van `org:hasUnit`."""@nl ;
     rdfs:isDefinedBy <http://www.w3.org/ns/org> .
-
-org:role a owl:ObjectProperty, rdf:Property;
-    rdfs:domain org:Post;
-    rdfs:range  org:Role;
-    rdfs:label "role"@en;
-    rdfs:label "rôle"@fr;
-    rdfs:label "ruolo"@it;
-    rdfs:comment """Indicates the Role that the Agent plays in a Membership relationship with an Organization."""@en;
-    rdfs:comment """Indique le Rôle de l'Agent dans son Engagement avec l'Organisation."""@fr;    
-    rdfs:comment """Indica il Role che un Agent ricopre in una relazione di Membership con una Organization"""@it;
-    rdfs:comment "エージェントが組織との構成員関係において担う役割を示します。ポストの保持者が担う役割を示すためにorg:Postで用いることもできます。"@ja;
-    rdfs:isDefinedBy <http://www.w3.org/ns/org> ;

--- a/organizations/organization-roles.skos.ttl
+++ b/organizations/organization-roles.skos.ttl
@@ -12,6 +12,7 @@
     skos:prefLabel "Staff"@en ;
     skos:prefLabel "Personnel(le)"@fr;
     skos:prefLabel "Personeel"@nl;
+    skos:inScheme <> ;
     skos:topConceptOf <>.
 
 <AccountManager> a org:Role ;

--- a/organizations/organization-roles.skos.ttl
+++ b/organizations/organization-roles.skos.ttl
@@ -8,21 +8,21 @@
   skos:prefLabel "Meemoo organization Roles thesaurus" ;
   skos:hasTopConcept <Staff> .
 
-<Staff> a org:Role ;
+<Staff> a org:Role, skos:Concept ;
     skos:prefLabel "Staff"@en ;
     skos:prefLabel "Personnel(le)"@fr;
     skos:prefLabel "Personeel"@nl;
     skos:inScheme <> ;
     skos:topConceptOf <>.
 
-<AccountManager> a org:Role ;
+<AccountManager> a org:Role, skos:Concept ;
     skos:prefLabel "Account Manager"@en ;
     skos:prefLabel "Gestionnaire de Comptes"@fr;
     skos:prefLabel "Accountmanager"@nl ;
     skos:broader <Staff> ;
     skos:inScheme <> .
 
-<EducationalEmployee> a org:Role ;
+<EducationalEmployee> a org:Role, skos:Concept ;
     skos:prefLabel "Educational employee"@en ;
     skos:prefLabel "Assistante pédagogique"@fr;
     skos:prefLabel "Educatief medewerker"@nl ;

--- a/organizations/organization-roles.skos.ttl
+++ b/organizations/organization-roles.skos.ttl
@@ -8,20 +8,20 @@
   skos:prefLabel "Meemoo organization Roles thesaurus" ;
   skos:hasTopConcept <Staff> .
 
-<Staff> a org:Role, skos:Concept;
+<Staff> a org:Role ;
     skos:prefLabel "Staff"@en ;
     skos:prefLabel "Personnel(le)"@fr;
     skos:prefLabel "Personeel"@nl;
     skos:topConceptOf <>.
 
-<AccountManager> a org:Role, skos:Concept;
+<AccountManager> a org:Role ;
     skos:prefLabel "Account Manager"@en ;
     skos:prefLabel "Gestionnaire de Comptes"@fr;
     skos:prefLabel "Accountmanager"@nl ;
     skos:broader <Staff> ;
     skos:inScheme <> .
 
-<EducationalEmployee> a org:Role, skos:Concept;
+<EducationalEmployee> a org:Role ;
     skos:prefLabel "Educational employee"@en ;
     skos:prefLabel "Assistante pédagogique"@fr;
     skos:prefLabel "Educatief medewerker"@nl ;

--- a/organizations/organization-types.skos.ttl
+++ b/organizations/organization-types.skos.ttl
@@ -12,7 +12,7 @@
 
 # --- top concept ---
 
-<GEN> a skos:Concept, haOrg:OrganizationType;
+<GEN> a haOrg:OrganizationType;
     skos:narrower <ALG>, <CUL>, <LEV>, <MED>, <OVH>;
     skos:inScheme <>;
     skos:topConceptOf <>;
@@ -20,122 +20,122 @@
 
 # --- Algemeen ---
 
-<ALG> a skos:Concept, haOrg:OrganizationType;
+<ALG> a haOrg:OrganizationType;
     skos:broader <GEN>;
     skos:narrower <advocatenbureau>, <kerkfabriek>, <kathedrale_kerkfabriek>, <sectororganisatie>;
     skos:inScheme <>;
     skos:prefLabel "Algemeen"@nl.
 
-<advocatenbureau> a skos:Concept, haOrg:OrganizationType;
+<advocatenbureau> a haOrg:OrganizationType;
     skos:broader <ALG>; 
     skos:inScheme <>;
     skos:prefLabel "Advocatenbureau"@nl.
 
-<kerkfabriek> a skos:Concept, haOrg:OrganizationType;
+<kerkfabriek> a haOrg:OrganizationType;
     skos:broader <ALG>; 
     skos:inScheme <>;
     skos:prefLabel "Kerkfabriek"@nl.
 
-<kathedrale_kerkfabriek> a skos:Concept, haOrg:OrganizationType;
+<kathedrale_kerkfabriek> a haOrg:OrganizationType;
     skos:broader <ALG>; 
     skos:inScheme <>;
     skos:prefLabel "Kathedrale kerkfabriek"@nl.
 
-<sectororganisatie> a skos:Concept, haOrg:OrganizationType;
+<sectororganisatie> a haOrg:OrganizationType;
     skos:broader <ALG>; 
     skos:inScheme <>;
     skos:prefLabel "Sectororganisatie"@nl.
 
 # --- Cultuur ---
 
-<CUL> a skos:Concept, haOrg:OrganizationType;
+<CUL> a haOrg:OrganizationType;
     skos:broader <GEN>;
     skos:inScheme <>;
     skos:narrower <kunstenorganisatie>, <erfgoedcel>, <openbare_bibliotheek>, <archief>, <erfgoedbibliotheek>, <museum_(niet_erkend)>, <museum_(erkend)>;
     skos:prefLabel "Cultuur/erfgoed"@nl.
 
-<kunstenorganisatie> a skos:Concept, haOrg:OrganizationType;
+<kunstenorganisatie> a haOrg:OrganizationType;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Kunstenorganisatie"@nl.
 
-<erfgoedcel> a skos:Concept, haOrg:OrganizationType;
+<erfgoedcel> a haOrg:OrganizationType;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Erfgoedcel"@nl.
 
-<openbare_bibliotheek> a skos:Concept, haOrg:OrganizationType;
+<openbare_bibliotheek> a haOrg:OrganizationType;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Openbare bibliotheek"@nl.
 
-<archief> a skos:Concept, haOrg:OrganizationType;
+<archief> a haOrg:OrganizationType;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Archief"@nl.
 
-<erfgoedbibliotheek> a skos:Concept, haOrg:OrganizationType;
+<erfgoedbibliotheek> a haOrg:OrganizationType;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Erfgoedbibliotheek"@nl.
 
-<museum_(niet_erkend)> a skos:Concept, haOrg:OrganizationType;
+<museum_(niet_erkend)> a haOrg:OrganizationType;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Museum (niet erkend)"@nl.
 
-<museum_(erkend)> a skos:Concept, haOrg:OrganizationType;
+<museum_(erkend)> a haOrg:OrganizationType;
     skos:broader <CUL>;
     skos:inScheme <>;
     skos:prefLabel "Museum (erkend)"@nl.
 
 # --- Leverancier ---
 
-<LEV> a skos:Concept, haOrg:OrganizationType;
+<LEV> a haOrg:OrganizationType;
     skos:broader <GEN>;
     skos:narrower <dienstenbedrijf>, <digitaliseringsbedrijf>, <technologiebedrijf> ;
     skos:inScheme <>;
     skos:prefLabel "Leverancier"@nl.
 
-<dienstenbedrijf> a skos:Concept, haOrg:OrganizationType;
+<dienstenbedrijf> a haOrg:OrganizationType;
     skos:broader <LEV>; 
     skos:inScheme <>;
     skos:prefLabel "Dienstenbedrijf"@nl.
 
-<digitaliseringsbedrijf> a skos:Concept, haOrg:OrganizationType;
+<digitaliseringsbedrijf> a haOrg:OrganizationType;
     skos:broader <LEV>; 
     skos:inScheme <>;
     skos:prefLabel "Digitaliseringsbedrijf"@nl.
 
-<technologiebedrijf> a skos:Concept, haOrg:OrganizationType;
+<technologiebedrijf> a haOrg:OrganizationType;
     skos:broader <LEV>; 
     skos:inScheme <>;
     skos:prefLabel "Technologiebedrijf"@nl.
 
 # --- Media ---
 
-<MED> a skos:Concept, haOrg:OrganizationType;
+<MED> a haOrg:OrganizationType;
     skos:broader <GEN>;
     skos:narrower <mediabedrijf>, <landelijke_private_omroep>, <regionale_omroep>, <publieke_omroep> ;
     skos:inScheme <>;
     skos:prefLabel "Media"@nl.
 
-<mediabedrijf> a skos:Concept, haOrg:OrganizationType;
+<mediabedrijf> a haOrg:OrganizationType;
     skos:broader <MED>; 
     skos:inScheme <>;
     skos:prefLabel "Mediabedrijf"@nl.
 
-<landelijke_private_omroep> a skos:Concept, haOrg:OrganizationType;
+<landelijke_private_omroep> a haOrg:OrganizationType;
     skos:broader <MED>;
     skos:inScheme <>;
     skos:prefLabel "Landelijke private omroep"@nl.
 
-<regionale_omroep> a skos:Concept, haOrg:OrganizationType;
+<regionale_omroep> a haOrg:OrganizationType;
     skos:broader <MED>;
     skos:inScheme <>;
     skos:prefLabel "Regionale omroep"@nl.
 
-<publieke_omroep> a skos:Concept, haOrg:OrganizationType;
+<publieke_omroep> a haOrg:OrganizationType;
     skos:broader <MED>;
     skos:inScheme <>;
     skos:prefLabel "Publieke omroep"@nl.
@@ -143,28 +143,28 @@
 
 # --- Overheid ---
 
-<OVH> a skos:Concept, haOrg:OrganizationType;
+<OVH> a haOrg:OrganizationType;
     skos:broader <GEN>;
     skos:narrower <adviescommissie>, <commissie_vlaams_parlement>, <kabinet>, <overheidsdienst>;
     skos:inScheme <>;
     skos:prefLabel "Overheid"@nl.
 
-<adviescommissie> a skos:Concept, haOrg:OrganizationType;
+<adviescommissie> a haOrg:OrganizationType;
     skos:broader <OVH>;
     skos:inScheme <>;
     skos:prefLabel "adviescommissie"@nl.
 
-<commissie_vlaams_parlement> a skos:Concept, haOrg:OrganizationType;
+<commissie_vlaams_parlement> a haOrg:OrganizationType;
     skos:broader <OVH>;
     skos:inScheme <>;
     skos:prefLabel "Commissie Vlaams Parlement"@nl.
 
-<kabinet> a skos:Concept, haOrg:OrganizationType;
+<kabinet> a haOrg:OrganizationType;
     skos:broader <OVH>;
     skos:inScheme <>;
     skos:prefLabel "Kabinet"@nl.
 
-<overheidsdienst> a skos:Concept, haOrg:OrganizationType;
+<overheidsdienst> a haOrg:OrganizationType;
     skos:broader <OVH>;
     skos:inScheme <>;
     skos:prefLabel "Overheidsdienst"@nl.
@@ -172,48 +172,48 @@
 
 # --- Onderwijs ---
 
-<OND> a skos:Concept, haOrg:OrganizationType;
+<OND> a haOrg:OrganizationType;
     skos:broader <GEN>;
     skos:narrower <hoger_onderwijs>, <leerplichtonderwijs>, <vakbond>, <educatieve_uitgeverij>, <educatieve_organisatie>, <vakvereniging_onderwijs>, <onderwijskoepel>;
     skos:inScheme <>;
     skos:prefLabel "Onderwijs"@nl.
 
-<hoger_onderwijs> a skos:Concept, haOrg:OrganizationType;
+<hoger_onderwijs> a haOrg:OrganizationType;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Hoger onderwijs"@nl.
 
-<leerplichtonderwijs> a skos:Concept, haOrg:OrganizationType;
+<leerplichtonderwijs> a haOrg:OrganizationType;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Leerplichtonderwijs"@nl.
 
-<vakbond> a skos:Concept, haOrg:OrganizationType;
+<vakbond> a haOrg:OrganizationType;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Vakbond"@nl.
 
-<educatieve_uitgeverij> a skos:Concept, haOrg:OrganizationType;
+<educatieve_uitgeverij> a haOrg:OrganizationType;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Educatieve uitgeverij"@nl.
 
-<educatieve_organisatie> a skos:Concept, haOrg:OrganizationType;
+<educatieve_organisatie> a haOrg:OrganizationType;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Educatieve organisatie"@nl.
 
-<vakvereniging_onderwijs> a skos:Concept, haOrg:OrganizationType;
+<vakvereniging_onderwijs> a haOrg:OrganizationType;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Vakvereniging onderwijs"@nl.
 
-<volwassenenonderwijs> a skos:Concept, haOrg:OrganizationType;
+<volwassenenonderwijs> a haOrg:OrganizationType;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Volwassenenonderwijs"@nl.
 
-<onderwijskoepel> a skos:Concept, haOrg:OrganizationType;
+<onderwijskoepel> a haOrg:OrganizationType;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Onderwijskoepel"@nl.

--- a/organizations/organization-types.skos.ttl
+++ b/organizations/organization-types.skos.ttl
@@ -6,8 +6,8 @@
 @base <https://data.hetarchief.be/id/organization-type/> .
 
 <https://data.hetarchief.be/id/organization-type> a skos:ConceptScheme;
-    rdfs:label "Meemoo organization classification thesaurus"@en;
-    rdfs:label "Meemoo lijst organisatietypes"@nl;
+    skos:prefLabel "Meemoo organization classification thesaurus"@en;
+    skos:prefLabel "Meemoo lijst organisatietypes"@nl;
     skos:hasTopConcept <GEN>.
 
 # --- top concept ---

--- a/organizations/organization-types.skos.ttl
+++ b/organizations/organization-types.skos.ttl
@@ -12,7 +12,7 @@
 
 # --- top concept ---
 
-<GEN> a haOrg:OrganizationType;
+<GEN> a haOrg:OrganizationType, skos:Concept;
     skos:narrower <ALG>, <CUL>, <LEV>, <MED>, <OVH>;
     skos:inScheme <>;
     skos:topConceptOf <>;
@@ -20,122 +20,122 @@
 
 # --- Algemeen ---
 
-<ALG> a haOrg:OrganizationType;
+<ALG> a haOrg:OrganizationType, skos:Concept;
     skos:broader <GEN>;
     skos:narrower <advocatenbureau>, <kerkfabriek>, <kathedrale_kerkfabriek>, <sectororganisatie>;
     skos:inScheme <>;
     skos:prefLabel "Algemeen"@nl.
 
-<advocatenbureau> a haOrg:OrganizationType;
+<advocatenbureau> a haOrg:OrganizationType, skos:Concept;
     skos:broader <ALG>; 
     skos:inScheme <>;
     skos:prefLabel "Advocatenbureau"@nl.
 
-<kerkfabriek> a haOrg:OrganizationType;
+<kerkfabriek> a haOrg:OrganizationType, skos:Concept;
     skos:broader <ALG>; 
     skos:inScheme <>;
     skos:prefLabel "Kerkfabriek"@nl.
 
-<kathedrale_kerkfabriek> a haOrg:OrganizationType;
+<kathedrale_kerkfabriek> a haOrg:OrganizationType, skos:Concept;
     skos:broader <ALG>; 
     skos:inScheme <>;
     skos:prefLabel "Kathedrale kerkfabriek"@nl.
 
-<sectororganisatie> a haOrg:OrganizationType;
+<sectororganisatie> a haOrg:OrganizationType, skos:Concept;
     skos:broader <ALG>; 
     skos:inScheme <>;
     skos:prefLabel "Sectororganisatie"@nl.
 
 # --- Cultuur ---
 
-<CUL> a haOrg:OrganizationType;
+<CUL> a haOrg:OrganizationType, skos:Concept;
     skos:broader <GEN>;
     skos:inScheme <>;
     skos:narrower <kunstenorganisatie>, <erfgoedcel>, <openbare_bibliotheek>, <archief>, <erfgoedbibliotheek>, <museum_(niet_erkend)>, <museum_(erkend)>;
     skos:prefLabel "Cultuur/erfgoed"@nl.
 
-<kunstenorganisatie> a haOrg:OrganizationType;
+<kunstenorganisatie> a haOrg:OrganizationType, skos:Concept;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Kunstenorganisatie"@nl.
 
-<erfgoedcel> a haOrg:OrganizationType;
+<erfgoedcel> a haOrg:OrganizationType, skos:Concept;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Erfgoedcel"@nl.
 
-<openbare_bibliotheek> a haOrg:OrganizationType;
+<openbare_bibliotheek> a haOrg:OrganizationType, skos:Concept;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Openbare bibliotheek"@nl.
 
-<archief> a haOrg:OrganizationType;
+<archief> a haOrg:OrganizationType, skos:Concept;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Archief"@nl.
 
-<erfgoedbibliotheek> a haOrg:OrganizationType;
+<erfgoedbibliotheek> a haOrg:OrganizationType, skos:Concept;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Erfgoedbibliotheek"@nl.
 
-<museum_(niet_erkend)> a haOrg:OrganizationType;
+<museum_(niet_erkend)> a haOrg:OrganizationType, skos:Concept;
     skos:broader <CUL>; 
     skos:inScheme <>;
     skos:prefLabel "Museum (niet erkend)"@nl.
 
-<museum_(erkend)> a haOrg:OrganizationType;
+<museum_(erkend)> a haOrg:OrganizationType, skos:Concept;
     skos:broader <CUL>;
     skos:inScheme <>;
     skos:prefLabel "Museum (erkend)"@nl.
 
 # --- Leverancier ---
 
-<LEV> a haOrg:OrganizationType;
+<LEV> a haOrg:OrganizationType, skos:Concept;
     skos:broader <GEN>;
     skos:narrower <dienstenbedrijf>, <digitaliseringsbedrijf>, <technologiebedrijf> ;
     skos:inScheme <>;
     skos:prefLabel "Leverancier"@nl.
 
-<dienstenbedrijf> a haOrg:OrganizationType;
+<dienstenbedrijf> a haOrg:OrganizationType, skos:Concept;
     skos:broader <LEV>; 
     skos:inScheme <>;
     skos:prefLabel "Dienstenbedrijf"@nl.
 
-<digitaliseringsbedrijf> a haOrg:OrganizationType;
+<digitaliseringsbedrijf> a haOrg:OrganizationType, skos:Concept;
     skos:broader <LEV>; 
     skos:inScheme <>;
     skos:prefLabel "Digitaliseringsbedrijf"@nl.
 
-<technologiebedrijf> a haOrg:OrganizationType;
+<technologiebedrijf> a haOrg:OrganizationType, skos:Concept;
     skos:broader <LEV>; 
     skos:inScheme <>;
     skos:prefLabel "Technologiebedrijf"@nl.
 
 # --- Media ---
 
-<MED> a haOrg:OrganizationType;
+<MED> a haOrg:OrganizationType, skos:Concept;
     skos:broader <GEN>;
     skos:narrower <mediabedrijf>, <landelijke_private_omroep>, <regionale_omroep>, <publieke_omroep> ;
     skos:inScheme <>;
     skos:prefLabel "Media"@nl.
 
-<mediabedrijf> a haOrg:OrganizationType;
+<mediabedrijf> a haOrg:OrganizationType, skos:Concept;
     skos:broader <MED>; 
     skos:inScheme <>;
     skos:prefLabel "Mediabedrijf"@nl.
 
-<landelijke_private_omroep> a haOrg:OrganizationType;
+<landelijke_private_omroep> a haOrg:OrganizationType, skos:Concept;
     skos:broader <MED>;
     skos:inScheme <>;
     skos:prefLabel "Landelijke private omroep"@nl.
 
-<regionale_omroep> a haOrg:OrganizationType;
+<regionale_omroep> a haOrg:OrganizationType, skos:Concept;
     skos:broader <MED>;
     skos:inScheme <>;
     skos:prefLabel "Regionale omroep"@nl.
 
-<publieke_omroep> a haOrg:OrganizationType;
+<publieke_omroep> a haOrg:OrganizationType, skos:Concept;
     skos:broader <MED>;
     skos:inScheme <>;
     skos:prefLabel "Publieke omroep"@nl.
@@ -143,28 +143,28 @@
 
 # --- Overheid ---
 
-<OVH> a haOrg:OrganizationType;
+<OVH> a haOrg:OrganizationType, skos:Concept;
     skos:broader <GEN>;
     skos:narrower <adviescommissie>, <commissie_vlaams_parlement>, <kabinet>, <overheidsdienst>;
     skos:inScheme <>;
     skos:prefLabel "Overheid"@nl.
 
-<adviescommissie> a haOrg:OrganizationType;
+<adviescommissie> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OVH>;
     skos:inScheme <>;
     skos:prefLabel "adviescommissie"@nl.
 
-<commissie_vlaams_parlement> a haOrg:OrganizationType;
+<commissie_vlaams_parlement> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OVH>;
     skos:inScheme <>;
     skos:prefLabel "Commissie Vlaams Parlement"@nl.
 
-<kabinet> a haOrg:OrganizationType;
+<kabinet> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OVH>;
     skos:inScheme <>;
     skos:prefLabel "Kabinet"@nl.
 
-<overheidsdienst> a haOrg:OrganizationType;
+<overheidsdienst> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OVH>;
     skos:inScheme <>;
     skos:prefLabel "Overheidsdienst"@nl.
@@ -172,48 +172,48 @@
 
 # --- Onderwijs ---
 
-<OND> a haOrg:OrganizationType;
+<OND> a haOrg:OrganizationType, skos:Concept;
     skos:broader <GEN>;
     skos:narrower <hoger_onderwijs>, <leerplichtonderwijs>, <vakbond>, <educatieve_uitgeverij>, <educatieve_organisatie>, <vakvereniging_onderwijs>, <onderwijskoepel>;
     skos:inScheme <>;
     skos:prefLabel "Onderwijs"@nl.
 
-<hoger_onderwijs> a haOrg:OrganizationType;
+<hoger_onderwijs> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Hoger onderwijs"@nl.
 
-<leerplichtonderwijs> a haOrg:OrganizationType;
+<leerplichtonderwijs> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Leerplichtonderwijs"@nl.
 
-<vakbond> a haOrg:OrganizationType;
+<vakbond> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Vakbond"@nl.
 
-<educatieve_uitgeverij> a haOrg:OrganizationType;
+<educatieve_uitgeverij> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Educatieve uitgeverij"@nl.
 
-<educatieve_organisatie> a haOrg:OrganizationType;
+<educatieve_organisatie> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Educatieve organisatie"@nl.
 
-<vakvereniging_onderwijs> a haOrg:OrganizationType;
+<vakvereniging_onderwijs> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Vakvereniging onderwijs"@nl.
 
-<volwassenenonderwijs> a haOrg:OrganizationType;
+<volwassenenonderwijs> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Volwassenenonderwijs"@nl.
 
-<onderwijskoepel> a haOrg:OrganizationType;
+<onderwijskoepel> a haOrg:OrganizationType, skos:Concept;
     skos:broader <OND>;
     skos:inScheme <>;
     skos:prefLabel "Onderwijskoepel"@nl.

--- a/organizations/organizations.rdfs.ttl
+++ b/organizations/organizations.rdfs.ttl
@@ -53,6 +53,7 @@ haOrg:EducationalPublisher a   rdfs:Class ;
     rdfs:isDefinedBy <https://data.hetarchief.be/ns/organization/> .
 
 haOrg:Logo a   rdfs:Class ;
+    rdfs:subClassOf schema:CreativeWork ;
     rdfs:label  "logo"@en ;
     rdfs:label  "logo"@fr ;
     rdfs:label  "logo"@nl ;

--- a/organizations/organizations.rdfs.ttl
+++ b/organizations/organizations.rdfs.ttl
@@ -53,7 +53,7 @@ haOrg:EducationalPublisher a   rdfs:Class ;
     rdfs:isDefinedBy <https://data.hetarchief.be/ns/organization/> .
 
 haOrg:Logo a   rdfs:Class ;
-    rdfs:subClassOf schema:CreativeWork ;
+    rdfs:subClassOf schema:ImageObject ;
     rdfs:label  "logo"@en ;
     rdfs:label  "logo"@fr ;
     rdfs:label  "logo"@nl ;

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -523,10 +523,11 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
   sh:property [
     a sh:PropertyShape ;
     sh:path schema:addressCountry ;
-    sh:maxCount 1 ;
     sh:or (
-      [ sh:datatype rdf:langString ]
-      [ sh:class schema:Country ]
+      [ sh:datatype rdf:langString ;
+        sh:uniqueLang true ]
+      [ sh:class schema:Country ;
+        sh:maxCount 1 ]
     );
     
     sh:name "country"@en ;

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -454,7 +454,6 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     a sh:PropertyShape ;
     sh:path haOrg:isAccountManagerOf ;
     sh:class org:Organization ;
-    sh:maxCount 1 ;
 
     sh:name "is account manager of"@en ;
     sh:name "est le Gestionnaire de Comptes de"@fr ;

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -520,15 +520,29 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
 
 <#PostalAddressShape>  a sh:NodeShape ;
   sh:targetClass schema:PostalAddress ;
-  sh:property [
+  sh:or ([
     a sh:PropertyShape ;
+    sh:datatype rdf:langString ;
     sh:path schema:addressCountry ;
-    sh:or (
-      [ sh:datatype rdf:langString ;
-        sh:uniqueLang true ]
-      [ sh:class schema:Country ;
-        sh:maxCount 1 ]
-    );
+    sh:uniqueLang true ;
+
+    sh:name "country"@en ;
+    sh:name "pays"@fr ;
+    sh:name "land"@nl ;
+
+    sh:description "The country in which the postal address is located."@en ;
+    sh:description "Le pays dans lequel se trouve l'adresse postale."@fr ;
+    sh:description "Het land waarin het postadres zich bevindt."@nl ;
+  
+    sh:message "The Object of schema:addressCountry is neither schema:Country nor rdf:langString."@en ;
+    sh:message "L'Object de schema:addressCountry n'est pas un schema:Country ou rdf:langString."@fr ;
+    sh:message "Het Object van schema:addressCountry is geen schema:Country of rdf:langString."@nl
+  ] 
+  [
+    a sh:PropertyShape ;
+    sh:class schema:Country ;
+    sh:path schema:addressCountry ;
+    sh:maxCount 1 ;
     
     sh:name "country"@en ;
     sh:name "pays"@fr ;
@@ -541,8 +555,8 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:message "The Object of schema:addressCountry is neither schema:Country nor rdf:langString."@en ;
     sh:message "L'Object de schema:addressCountry n'est pas un schema:Country ou rdf:langString."@fr ;
     sh:message "Het Object van schema:addressCountry is geen schema:Country of rdf:langString."@nl
-  ],
-  [   
+  ]);
+  sh:property [   
     a  sh:PropertyShape ;
     sh:path schema:addressLocality ;
     sh:datatype xsd:string ;

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -199,7 +199,7 @@
     sh:message "occurs more than once or its value is no org:Site"@en 
   ],
   [
-    sh:path haOrg:hasAccountmanager ;
+    sh:path haOrg:hasAccountManager ;
     sh:maxCount 1 ;
     sh:class schema:Person ;
 

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -364,7 +364,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     a sh:PropertyShape ;
     sh:path skos:prefLabel ;
     sh:minCount 1 ;
-    sh:maxCount 1 ;
+    sh:uniqueLang true ;
     sh:datatype rdf:langString ;
       
     sh:name "preferred label"@en ;
@@ -376,8 +376,8 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "Le nom / étiquette préféré du rôle."@fr ;
       
     sh:message "skos:prefLabel is missing or its Object is no rdf:langString."@en ;
-    sh:message "skos:prefLabel is missing or its Object is no rdf:langString."@fr ;
-    sh:message "skos:prefLabel is missing or its Object is no rdf:langString."@nl 
+    sh:message "skos:prefLabel  est absent ou son Object n'est pas un rdf:langString."@fr ;
+    sh:message "skos:prefLabel ontbreekt of het object is geen rdf:langString."@nl 
 
   ] .
 
@@ -453,10 +453,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
   [
     a sh:PropertyShape ;
     sh:path haOrg:isAccountManagerOf ;
-    sh:or (
-      [ sh:class haOrg:ContentPartner  ]
-      [ sh:class haOrg:EducationalPartner ]
-    );
+    sh:class org:Organization ;
     sh:maxCount 1 ;
 
     sh:name "is account manager of"@en ;

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -18,15 +18,16 @@
 <>  a owl:Ontology;
     vann:preferredNamespacePrefix "haOrg" ;
     vann:preferredNamespaceUri "http://data.hetarchief.be/ns/organization/" ;
-    dct:author  [
+    schema:author  [
+        a schema:Person ;
         schema:name   "Miel Vander Sande" ;
         schema:email  "miel.vandersande@meemoo.be"
-    ] ,
-                [
+    ] , [
+        a schema:Person ;
         schema:name   "Milan Valadou" ;
         schema:email  "milan.valadou@meemoo.be"
-    ] ,
-    [
+    ] , [
+        a schema:Person ;
         schema:name   "Lennert Van de Velde" ;
         schema:email  "lennert.vandevelde@meemoo.be"
     ] ;
@@ -82,6 +83,7 @@
     sh:message "is no langString"@en
   ],
   [
+    a sh:PropertyShape ;
     sh:path haOrg:hasLogo ;
     sh:class haOrg:Logo ;
 
@@ -97,6 +99,7 @@
     sh:message "is no haOrg:Logo"@en ;
   ], 
   [
+    a sh:PropertyShape ;
     sh:path foaf:homepage ;
     sh:maxCount 1 ;
     sh:nodeKind sh:IRI ;
@@ -112,6 +115,7 @@
     sh:message "occurs more than once or its object is no valid IRI"@en ;
   ],
   [
+    a sh:PropertyShape ;
     sh:path dct:description ;
     sh:maxCount 1 ;
     sh:nodeKind sh:Literal ;
@@ -128,6 +132,7 @@
     sh:message "is not of type xsd:string or occurs more than once"@en ;
   ],
   [
+    a sh:PropertyShape ;
     sh:path org:classification ;
     sh:class haOrg:OrganizationType ;
 
@@ -142,6 +147,7 @@
     sh:message "is no haOrg:OrganizationType"@en ;
   ],
   [
+    a sh:PropertyShape ;
     sh:path org:hasUnit ;
     sh:class org:OrganizationalUnit ;
 
@@ -156,6 +162,7 @@
     sh:message "is no org:OrganizationalUnit"@en ;
   ],
   [
+    a sh:PropertyShape ;
     sh:path schema:contactPoint ;
     sh:class schema:ContactPoint ;
     
@@ -170,6 +177,7 @@
     sh:message "is no schema:ContactPoint"@en ;
   ],
   [
+    a sh:PropertyShape ;
     sh:path org:hasSite ;
     sh:class org:Site ;
     
@@ -184,6 +192,7 @@
     sh:message "occurs more than once or its Object is no org:Site"@en ;
   ],
   [
+    a sh:PropertyShape ;
     sh:path org:hasPrimarySite ;
     sh:maxCount 1 ;
     sh:class org:Site ;
@@ -199,6 +208,7 @@
     sh:message "occurs more than once or its value is no org:Site"@en 
   ],
   [
+    a sh:PropertyShape ;
     sh:path haOrg:hasAccountManager ;
     sh:maxCount 1 ;
     sh:class schema:Person ;
@@ -214,6 +224,7 @@
     sh:message "occurs more than once or its value is no schema:Person"@en 
   ],
   [
+    a sh:PropertyShape ;
     sh:path org:hasPost ;
     sh:class org:Post ;
 
@@ -231,6 +242,7 @@
 haOrg:OrganizationalUnitShape a sh:NodeShape ;
   sh:targetClass org:OrganizationalUnit ;
   sh:property [
+    a sh:PropertyShape ;
     sh:path org:unitOf ;
     sh:minCount 1 ;
     sh:class org:Organization ;
@@ -249,6 +261,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
 <#ContentPartnerShape> a sh:NodeShape ;
   sh:targetClass haOrg:ContentPartner ;
   sh:property [
+    a sh:PropertyShape ;
     sh:path haOrg:hasAccountManager ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
@@ -268,6 +281,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
 <#EducationalPartnerShape>  a sh:NodeShape ;
   sh:targetClass haOrg:EducationalPartner ;
   sh:property [
+    a sh:PropertyShape ;
     sh:path haOrg:hasAccountManager ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
@@ -287,6 +301,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
 <#SiteShape>  a  sh:NodeShape ;
   sh:targetClass org:Site ;
   sh:property [
+    a sh:PropertyShape ;
     sh:path org:siteAddress ;
     sh:maxCount 1 ;
     sh:class schema:PostalAddress ;
@@ -306,7 +321,8 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
 
 <#PostShape> a sh:NodeShape;
   sh:targetClass org:Post ;
-  sh:property [        
+  sh:property [    
+    a sh:PropertyShape ;    
     sh:path org:role ;
     sh:minCount 1 ;
     sh:class org:Role ;
@@ -323,7 +339,8 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:message "org:role est absent ou son Object n'est pas un org:Role"@fr ;
     sh:message "org:role ontbreekt of zijn Object is geen org:Role"@nl ;
   ],
-  [                
+  [            
+    a sh:PropertyShape ;    
     sh:path org:postIn ;
     sh:minCount 1 ;
     sh:class org:Organization ;
@@ -367,6 +384,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
 <#PersonShape> a sh:NodeShape ;
   sh:targetClass schema:Person ;
   sh:property [    
+    a sh:PropertyShape ;
     sh:path org:holds ;
     sh:class org:Post ;
 
@@ -378,11 +396,12 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "Le poste que la personne occupe dans l'organisation."@fr ;
     sh:description "De positie die de persoon binnen de organisatie bekleedt."@nl ;
 
-    sh:message "org:holds is missing or the datatype is no org:Post"@en ;
+    sh:message "org:holds is missing or the object is no org:Post"@en ;
     sh:message "org:holds est absent ou son Object n'est pas un org:Post"@fr ;
-    sh:message "org:holds ontbreekt of het datatype is geen org:Post"@nl
+    sh:message "org:holds ontbreekt of het object is geen org:Post"@nl
   ],
   [    
+    a sh:PropertyShape ;
     sh:path schema:givenName ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
@@ -399,6 +418,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:message "schema:givenName is missing or the datatype is no xsd:string."@en ;
   ],
   [    
+    a sh:PropertyShape ;
     sh:path schema:familyName ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
@@ -415,6 +435,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:message "schema:familyName is missing or the datatype is no xsd:string."@en ;
   ],
   [
+    a sh:PropertyShape ;
     sh:path schema:email ;
     sh:datatype xsd:string ;
 
@@ -430,8 +451,12 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:message "schema:email is missing or the datatype is no xsd:string."@en ;
   ],
   [
+    a sh:PropertyShape ;
     sh:path haOrg:isAccountManagerOf ;
-    sh:class org:Organization ;
+    sh:or (
+      [ sh:class haOrg:ContentPartner  ]
+      [ sh:class haOrg:EducationalPartner ]
+    );
     sh:maxCount 1 ;
 
     sh:name "is account manager of"@en ;
@@ -503,8 +528,11 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     a sh:PropertyShape ;
     sh:path schema:addressCountry ;
     sh:maxCount 1 ;
-    sh:datatype rdf:langString ;
-  
+    sh:or (
+      [ sh:datatype rdf:langString ]
+      [ sh:class schema:Country ]
+    );
+    
     sh:name "country"@en ;
     sh:name "pays"@fr ;
     sh:name "land"@nl ;
@@ -531,7 +559,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "La ville dans laquelle se trouve l'adresse postale, et qui est dans la région. Par exemple, Mountain View."@fr ;
     sh:description "De stad waarin het straatadres zich bevindt, en deel uitmaakt van de regio. Bijvoorbeeld, Brussel, Oostende, ...."@nl ;
 
-    sh:message "not an xsd:string or occurs more than once."@en ;
+    sh:message "Not an xsd:string or occurs more than once."@en ;
   ],
   [   
     a sh:PropertyShape ;
@@ -547,7 +575,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "La région dans laquelle la ville est, et qui est dans le pays. Par exemple, Californie ou une autre division administrative appropriée."@fr ;
     sh:description "De provincie van het land waarin de stad zich bevindt. Bijvoorbeeld, Oost-Vlaanderen, Limburg, etc."@nl ;
 
-    sh:message "not an xsd:string or occurs more than once."@en ;
+    sh:message "Not an xsd:string or occurs more than once."@en ;
   ],
   [   
     a sh:PropertyShape ;
@@ -563,7 +591,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "Le numéro de boîte postale pour les adresses de boîte postale."@fr ;
     sh:description "Het postbusnummer voor postbusadressen."@nl ;
 
-    sh:message "not an xsd:string or occurs more than once."@en ;
+    sh:message "Not an xsd:string or occurs more than once."@en ;
   ],
   [  
     a sh:PropertyShape ;
@@ -579,7 +607,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "Le code postal. Par exemple, 94043."@fr ;
     sh:description "De postcode. Bijvoorbeeld, 9400."@nl ;
 
-    sh:message "not an xsd:string or occurs more than once."@en ;
+    sh:message "Not an xsd:string or occurs more than once."@en ;
   ],
   [   
     a sh:PropertyShape ;
@@ -595,12 +623,13 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "L'adresse postale. Par exemple, 1600 Amphitheatre Parkway."@fr ;
     sh:description "Het straatadres. Bijvoorbeeld, Kerkstraat 16."@nl ;
 
-    sh:message "not an xsd:string or occurs more than once."@en ;
+    sh:message "Not an xsd:string or occurs more than once."@en ;
 ].
 
 <#ContactPointShape>  a sh:NodeShape ;
   sh:targetClass schema:ContactPoint ;
   sh:property [  
+    a sh:PropertyShape ;
     sh:path schema:contactType ;
     sh:datatype xsd:string ;
     sh:minCount 1 ;
@@ -615,6 +644,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "Le type de point de contact."@fr ;
   ],
   [ 
+    a sh:PropertyShape ;
     sh:path schema:email ;
     sh:datatype xsd:string ;
     
@@ -626,6 +656,7 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "Het e-mail adres."@nl ;
     sh:description "L'adresse e-mail."@fr ;
   ],[ 
+    a sh:PropertyShape ;
     sh:path schema:telephone ;
     sh:datatype xsd:string ;
     


### PR DESCRIPTION
Voor de reviewer:
Het datamodel voor Organizations is gereviewed. Op basis van de review zijn een aantal aanpassingen die doorgevoerd kunnen worden in het datamodel.
Tijdens de review zijn de volgende dingen omhoog gekomen:
 - Een typo in een property
 - Consistent maken van het gebruik van labels per dataset
 - Toevoegen van een paar eigenschappen en klassen die wel gebruikt waren maar niet voorkwamen in het gepruned `org` datamodel.
 - Toevoegen van de `rdf:type sh:PropertyShape` relatie voor propertyshapes zonder klasse.
 - Toevoegen van shacl Or statement zodat de propertyShape de sh:message volgt.
 - Updaten van een aantal labels.
Het shacl model is ook gevalideerd volgens de SHACL-SHACL standaard en daar zijn geen foutmeldingen uitgekomen.
