### PR TITLE
KG-8 Revert addressCountry to xsd:string or schema:Country

### DIFF
--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -520,27 +520,13 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
 
 <#PostalAddressShape>  a sh:NodeShape ;
   sh:targetClass schema:PostalAddress ;
-  sh:or ([
-    a sh:PropertyShape ;
-    sh:datatype rdf:langString ;
-    sh:path schema:addressCountry ;
-    sh:uniqueLang true ;
-
-    sh:name "country"@en ;
-    sh:name "pays"@fr ;
-    sh:name "land"@nl ;
-
-    sh:description "The country in which the postal address is located."@en ;
-    sh:description "Le pays dans lequel se trouve l'adresse postale."@fr ;
-    sh:description "Het land waarin het postadres zich bevindt."@nl ;
-  
-    sh:message "The Object of schema:addressCountry is neither schema:Country nor rdf:langString."@en ;
-    sh:message "L'Object de schema:addressCountry n'est pas un schema:Country ou rdf:langString."@fr ;
-    sh:message "Het Object van schema:addressCountry is geen schema:Country of rdf:langString."@nl
-  ] 
+  sh:property
   [
     a sh:PropertyShape ;
-    sh:class schema:Country ;
+    sh:or (
+      [ sh:datatype xsd:string ]
+      [ sh:class schema:Country ]
+    );
     sh:path schema:addressCountry ;
     sh:maxCount 1 ;
     
@@ -552,11 +538,11 @@ haOrg:OrganizationalUnitShape a sh:NodeShape ;
     sh:description "Le pays dans lequel se trouve l'adresse postale."@fr ;
     sh:description "Het land waarin het postadres zich bevindt."@nl ;
   
-    sh:message "The Object of schema:addressCountry is neither schema:Country nor rdf:langString."@en ;
-    sh:message "L'Object de schema:addressCountry n'est pas un schema:Country ou rdf:langString."@fr ;
-    sh:message "Het Object van schema:addressCountry is geen schema:Country of rdf:langString."@nl
-  ]);
-  sh:property [   
+    sh:message "The Object of schema:addressCountry is neither schema:Country nor xsd:string."@en ;
+    sh:message "L'Object de schema:addressCountry n'est pas un schema:Country ou xsd:string."@fr ;
+    sh:message "Het Object van schema:addressCountry is geen schema:Country of xsd:string."@nl
+  ],
+  [   
     a  sh:PropertyShape ;
     sh:path schema:addressLocality ;
     sh:datatype xsd:string ;


### PR DESCRIPTION
`schema:addressCountry` als `rdf:langString` was a misconception on my part. This should indeed be xsd:string, which in turn makes the `sh:or` construct obsolete. Apologies