### PR TITLE
Kg 58 modelleren van organisatievoorkeuren

### DIFF
--- a/organizations/organizations.rdfs.ttl
+++ b/organizations/organizations.rdfs.ttl
@@ -156,3 +156,14 @@ haOrg:hasLogo  a   rdf:Property ;
     skos:definition "Un logo pour une organisation."@fr ;
     skos:definition "Een logo voor een organisatie."@nl ;
     rdfs:isDefinedBy <https://data.hetarchief.be/ns/organization/> .
+
+haOrg:permits a rdf:Property ;
+    rdfs:domain org:ContentPartner ;
+    rdfs:range rdfs:Literal ;
+    rdfs:label "geeft toelating voor"@nl ;
+    rdfs:label "gives permission for"@en ;
+    rdfs:label "accorde la permission"@fr ;
+    skos:definition "Geeft een bepaalde toelating om het materiaal, waarvan deze organisatie eigenaar is, te ontsluiten of te presenteren."@nl;
+    skos:definition "Gives a certain admission to disseminate or present the content of which this organization is the owner."@en;
+    skos:definition "Donne une certaine admission pour diffuser ou présenter le contenu dont cette organisation est propriétaire."@fr;
+    rdfs:isDefinedBy <https://data.hetarchief.be/ns/organization/> .

--- a/organizations/organizations.rdfs.ttl
+++ b/organizations/organizations.rdfs.ttl
@@ -163,7 +163,7 @@ haOrg:permits a rdf:Property ;
     rdfs:label "geeft toelating voor"@nl ;
     rdfs:label "gives permission for"@en ;
     rdfs:label "accorde la permission"@fr ;
-    skos:definition "Geeft een bepaalde toelating om het materiaal, waarvan deze organisatie eigenaar is, te ontsluiten of te presenteren."@nl;
-    skos:definition "Gives a certain admission to disseminate or present the content of which this organization is the owner."@en;
-    skos:definition "Donne une certaine admission pour diffuser ou présenter le contenu dont cette organisation est propriétaire."@fr;
+    skos:definition "Geeft een bepaalde toelating om het materiaal, waarvan deze contentpartner eigenaar is, te ontsluiten of te presenteren."@nl;
+    skos:definition "Gives a certain admission to disseminate or present the content of which this content partner is the owner."@en;
+    skos:definition "Donne une certaine admission pour diffuser ou présenter le contenu dont cette contentpartner est propriétaire."@fr;
     rdfs:isDefinedBy <https://data.hetarchief.be/ns/organization/> .

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -425,6 +425,23 @@
     sh:description "Verwijst naar de unieke ID van de contentpartner."@nl ;
 
     sh:message "is missing, occurs more than once or its object is no xsd:string"@en ;
+  ] ,
+  [
+    a sh:PropertyShape ;
+    sh:path haOrg:permits ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype xsd:string ;
+    sh:in ("bezoekertool" "overlay") ;
+
+    rdfs:label "geeft toelating voor"@nl ;
+    rdfs:label "gives permission for"@en ;
+    rdfs:label "accorde la permission"@fr ;
+    
+    sh:description "Geeft een bepaalde toelating om het materiaal, waarvan deze contentpartner eigenaar is, te ontsluiten of te presenteren."@nl;
+    sh:description "Gives a certain admission to disseminate or present the content of which this content partner is the owner."@en;
+    sh:description "Donne une certaine admission pour diffuser ou présenter le contenu dont cette contentpartner est propriétaire."@fr;
+
+    sh:message "is missing, occurs more than once or its object is no xsd:string"@en ;
   ] .
   
 


### PR DESCRIPTION
Dit is een tijdelijke, iets betere modellering voor de functionele properties `haOrg:allowsOverlay`, `haOrg:allowsBZT`. Later moeten we van deze waarden een gecontroleerde lijst maken of met ODRL beschrijven.

```
<x> a haOrg:ContentPartner; 
haOrg:permits "bezoekertool", "overlay".

```