### PR TITLE
Kg 81 fix mediahaven allows bzt allows overlay in het organisatie datamodel

### DIFF
--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -446,18 +446,39 @@
   ] ,
   [
     a sh:PropertyShape ;
-    sh:path haOrg:permits ;
+    sh:path haOrg:allowsBZT ;
     sh:nodeKind sh:Literal ;
-    sh:datatype xsd:string ;
-    sh:in ("bezoekertool" "overlay") ;
+    sh:datatype xsd:boolean ;
 
-    rdfs:label "geeft toelating voor"@nl ;
-    rdfs:label "gives permission for"@en ;
-    rdfs:label "accorde la permission"@fr ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+
+    rdfs:label "laat bezoekertool toe"@nl ;
+    rdfs:label "allows bezoekertool"@en ;
+    rdfs:label "permet le bezoekertool"@fr ;
     
-    sh:description "Geeft een bepaalde toelating om het materiaal, waarvan deze contentpartner eigenaar is, te ontsluiten of te presenteren."@nl;
-    sh:description "Gives a certain admission to disseminate or present the content of which this content partner is the owner."@en;
-    sh:description "Donne une certaine admission pour diffuser ou présenter le contenu dont cette contentpartner est propriétaire."@fr;
+    sh:description "Geeft toelating om het materiaal, waarvan deze contentpartner eigenaar is, te ontsluiten op de Bezoekertool van meemoo."@nl;
+    sh:description "Gives admission to disseminate the content of which this content partner is the owner on the Bezoekertool of meemoo."@en;
+    sh:description "Donne admission pour diffuser le contenu dont cette contentpartner est propriétaire sur le Bezoekertool de meemoo."@fr;
+
+    sh:message "is missing, occurs more than once or its object is no xsd:boolean"@en ;
+  ] ,
+  [
+    a sh:PropertyShape ;
+    sh:path haOrg:allowsOverlay ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype xsd:boolean ;
+
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+
+    rdfs:label "laat overlay toe"@nl ;
+    rdfs:label "allows overlay"@en ;
+    rdfs:label "permet la superposition"@fr ;
+    
+    sh:description "Geeft toelating om het materiaal, waarvan deze contentpartner eigenaar is, te presenteren met een watermerk."@nl;
+    sh:description "Gives admission to present the content of which this content partner is the owner with an overlay."@en;
+    sh:description "Donne admission pour présenter le contenu dont cette contentpartner est propriétaire avec une superposition."@fr;
 
     sh:message "is missing, occurs more than once or its object is no xsd:string"@en ;
   ] .

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -480,7 +480,7 @@
     sh:description "Gives admission to present the content of which this content partner is the owner with an overlay."@en;
     sh:description "Donne admission pour présenter le contenu dont cette contentpartner est propriétaire avec une superposition."@fr;
 
-    sh:message "is missing, occurs more than once or its object is no xsd:string"@en ;
+    sh:message "is missing, occurs more than once or its object is no xsd:boolean"@en ;
   ] .
   
 

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -12,6 +12,7 @@
 @prefix edtf: <http://id.loc.gov/datatypes/edtf/> .
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix pav: <http://purl.org/pav/> .
+@prefix mh: <https://data.hetarchief.be/ns/mediahaven/> .
 
 @base <https://data.hetarchief.be/ns/organization> .
 
@@ -82,6 +83,21 @@
     sh:name "alternatieve naam/label"@nl ;
       
     sh:message "is no language string"@en
+  ],
+  [ 
+    a sh:PropertyShape ;
+    sh:path mh:label ;
+    sh:datatype xsd:string ;
+
+    sh:description "The Mediahaven tenant name of the organization."@en ;
+    sh:description "Le nom du locataire Mediahaven de l'organisation."@fr ;
+    sh:description "De Mediahaven tenant naam van de organisatie."@nl ;
+
+    sh:name "tenant name"@en ;
+    sh:name "nom du locataire Mediahaven"@fr ;
+    sh:name "tenant naam"@nl ;
+      
+    sh:message "is no string"@en
   ],
   [
     a sh:PropertyShape ;


### PR DESCRIPTION
Dit is een hotfix op het het Organisatie datamodel:

- [x] mh:label ontbreekt
- [x] allowsBZT en allowsOverlay draaien we terug tot we een echte oplossing hebben

Dit brengt het model in lijn met het voorbeeldrecord.