### PR TITLE
KG-369 Add telephone property to schema:Person

### DIFF
--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -691,6 +691,22 @@
   ],
   [
     a sh:PropertyShape ;
+    sh:path schema:telephone ;
+    sh:datatype xsd:string ;
+
+    sh:name "telephone"@en ;
+    sh:name "telefoon"@nl ;
+    sh:name "téléphone"@fr ;
+    
+    sh:description "Telephone of this person."@en ;
+    sh:description "Telefoon van deze persoon."@nl ;
+    sh:description "Téléphone de cette personne."@fr ;
+
+    sh:severity sh:Info ;
+    sh:message "its object is no xsd:string"@en ;
+  ],
+  [
+    a sh:PropertyShape ;
     sh:path haOrg:isAccountManagerOf ;
     sh:class org:Organization ;
 


### PR DESCRIPTION
This property[^1] is used in the [teamleader user ETL](https://github.com/viaacode/prefect-flow-organization-etl/blob/2716f0c4e9902a985cd0bd12c40e59e3b5f2967e/triplyetl/src/teamleader_users.ts#L61).

[^1]: https://schema.org/telephone