### PR TITLE
Create CreativeWorkSeason

### DIFF
--- a/description/description.shacl.ttl
+++ b/description/description.shacl.ttl
@@ -865,6 +865,66 @@
         sh:message "schema:isPartOf n'est pas de la classe schema:CreativeWorkSeries."@fr ;
     ].
 
+<#CreativeWorkSeasonShape> a sh:NodeShape ; 
+    sh:targetClass schema:CreativeWorkSeason ;
+    sh:property <#NameShape>, <#DescriptionShape>,
+    [
+        a sh:PropertyShape ;
+        sh:path schema:identifier ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:name "identifier"@en ;
+        sh:name "identifier"@nl ;
+        sh:name "identifier"@fr ;
+        sh:severity sh:Violation ;
+        sh:message "schema:identifier occurs more than once or is not of type string "@en ;
+    ],
+    [
+        a sh:PropertyShape ;
+        sh:path schema:seasonNumber ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:integer ;
+        sh:name "season number"@en ;
+        sh:name "seizoensnummer"@nl ;
+        sh:name "numéro de saison"@fr ;
+        sh:severity sh:Violation ;
+        sh:message "schema:seasonNumber is not of type integer"@en ;
+        sh:message "schema:seasonNumber is niet van het type integer"@nl ;
+        sh:message "schema:seasonNumber n'est pas de type integer"@fr ;
+    ] ,
+    [
+        a sh:PropertyShape ;
+        sh:path schema:hasPart ;
+        sh:or (
+            [ sh:class premis:IntellectualEntity ]
+            [ sh:class schema:CreativeWorkSeries ]
+        );
+        sh:description "Indicates an IntellectualEntity or CreativeWork that is part of this series."@en ;
+        sh:description "Geeft aan dat deze IntellectualEntity of CreativeWork deel uitmaakt van deze serie."@nl ;
+        sh:description "Indique une intellectualité ou un travail créatif qui fait partie de cette saison."@fr ;
+        sh:name "has part"@en ;
+        sh:name "is deel van"@nl ;
+        sh:name "fait partie de"@fr ;
+        sh:severity sh:Violation ;
+        sh:message "schema:hasPart is not of class premis:IntellectualEntity"@en ;
+        sh:message "schema:hasPart is niet van de klasse premis:IntellectualEntity"@nl ;
+        sh:message "schema:hasPart n'est pas de la classe premis:IntellectualEntity"@fr ;
+    ] ,
+    [
+        a sh:PropertyShape ;
+        sh:path schema:isPartOf ;
+        sh:class schema:CreativeWorkSeries ;
+        sh:name "is part of"@en ;
+        sh:name "is een deel van"@nl ;
+        sh:name "est partie de"@fr ;
+        sh:severity sh:Violation ;
+        sh:message "schema:isPartOf is not of class schema:CreativeWorkSeries."@en ;
+        sh:message "schema:isPartOf is niet van de klasse schema:CreativeWorkSeries."@nl ;
+        sh:message "schema:isPartOf n'est pas de la classe schema:CreativeWorkSeries."@fr ;
+    ].
+
 <#EpisodeShape> a sh:NodeShape ; 
     sh:targetClass schema:Episode ;
     sh:property <#IdentifierShape>, <#NameShape>, <#DescriptionShape> ,

--- a/description/description.shacl.ttl
+++ b/description/description.shacl.ttl
@@ -823,17 +823,17 @@
     ],
     [
         a sh:PropertyShape ;
-        sh:path schema:seasonNumber ;
+        sh:path schema:position ;
         sh:nodeKind sh:Literal ;
         sh:datatype xsd:integer ;
-        sh:name "season number"@en ;
-        sh:name "seizoensnummer"@nl ;
-        sh:name "numéro de saison"@fr ;
+        sh:name "position"@en ;
+        sh:name "positie"@nl ;
+        sh:name "position"@fr ;
         sh:severity sh:Violation ;
-        sh:message "schema:seasonNumber is not of type integer"@en ;
-        sh:message "schema:seasonNumber is niet van het type integer"@nl ;
-        sh:message "schema:seasonNumber n'est pas de type integer"@fr ;
-    ] ,
+        sh:message "schema:position is not of type integer"@en ;
+        sh:message "schema:position is niet van het type integer"@nl ;
+        sh:message "schema:position n'est pas de type integer"@fr ;
+    ],
     [
         a sh:PropertyShape ;
         sh:path schema:hasPart ;

--- a/ontologies/schema.rdfs.ttl
+++ b/ontologies/schema.rdfs.ttl
@@ -668,6 +668,17 @@ schema:containedInPlace a rdf:Property ;
     skos:definition "La relation de confinement de base entre un lieu et une qui le contient."@fr;
     rdfs:isDefinedBy <https://schema.org/> .
 
+schema:position a rdf:Property ;
+    rdfs:domain schema:CreativeWork ;
+    rdfs:range xsd:integer ;
+    rdfs:label "position"@en ;
+    rdfs:label "positie"@nl ;
+    rdfs:label "position"@fr ;
+    skos:definition "The position of an item in a series or sequence of items."@en;
+    skos:definition "De positie van een item in een reeks of opeenvolging van items."@nl;
+    skos:definition "La position d'un élément dans une série ou une séquence d'éléments."@fr;
+    rdfs:isDefinedBy <https://schema.org/> .
+
 schema:postalCode   a   rdf:Property ;
     schema:domainIncludes schema:DefinedRegion,
         schema:GeoCoordinates,


### PR DESCRIPTION
CreativeWorkSeries has `schema:seasonNumber` as a property in our datamodel. This is not how it is defined in schema. `schema:position` is what it should be (as you noted in this comment: https://docs.google.com/spreadsheets/d/1s_cVmYxL3u84mr__rrrr1xevZOZMJ2aJySpMmB7YHFY/edit?disco=AAAA5ZQZUvE).

I added CreativeWorkSeason since it was missing. I will also open a PR in the KG ETL.


One creative work that is not present here, but is present in the SIP spec is `schema:BroadcastEvent`. Do we have a use case for it?