### PR TITLE
Fix ebucore:hasCaptioning target class

### DIFF
--- a/description/description.shacl.ttl
+++ b/description/description.shacl.ttl
@@ -656,7 +656,7 @@
     [
         a sh:PropertyShape ;
         sh:path ebucore:hasCaptioning;
-        sh:and (
+        sh:or (
             [ sh:class premis:File ]
             [ sh:class ebucore:ClosedCaptions ]
         );
@@ -666,7 +666,7 @@
         sh:name "ondertiteling"@nl ;
 
         sh:description "De ondertitels of transcriptie van dit bestand."@nl ;
-        sh:description "De ondertitels of transcriptie van dit bestand."@en ;
+        sh:description "The subtitles or transcription of this file."@en ;
         sh:description "Les sous-titres ou transcription de ce fichier."@fr ;
 
         sh:message "ebucore:hasCaptioning is missing, not a premis:File or not a ebucore:ClosedCaptions."@en ;


### PR DESCRIPTION
There is a missing datatype for `ebucore:hasCaptioning`: https://developer.meemoo.be/docs/metadata/knowledge-graph/1.0.0/description/en/#file-premisfile

I'm not sure how to use shacl2md or where it happens in the CI, so I haven't tested this change.