### PR TITLE
Remove redundant storedAt contraint on Reels

### DIFF
--- a/description/film.shacl.ttl
+++ b/description/film.shacl.ttl
@@ -216,27 +216,4 @@
         sh:message "l'objet de haDes:numberOfReels n'est pas de type xsd:nonNegativeInteger, ou apparaît plus d'une seule fois"@fr ;
         sh:message "het object van haDes:numberOfReels is niet van het type xsd:nonNegativeInteger, of komt meer dan eens voor"@nl ;
         sh:severity sh:Violation
-    ] ,
-    [
-        a sh:PropertyShape ;
-        sh:path premis:storedAt ;
-        sh:or (
-        [ sh:class haDes:ImageReel] 
-        [ sh:class haDes:AudioReel] 
-        ) ;
-        sh:minCount 1 ;
-
-        sh:name "stored at"@en ;
-        sh:name "opgeslagen op"@nl ;
-        sh:name "stocké à"@fr ;
-
-        sh:description "De spoel waarop de representatie is opgeslagen."@nl ;
-        sh:description "The reel where the representation is stored."@en ;
-        sh:description "Le porteur physique où la représentation est stocké."@fr ;
-
-        sh:message "premis:storedAt has more than one value, no values or not a haObj:PhysicalCarrier"@en ;
-        sh:message "premis:storedAt heeft meer dan één of geen waarde of is geen haObj:PhysicalCarrier"@nl ;
-        sh:message "premis:storedAt a plus d'une valeur, pas de valeur ou n'est pas une haObj:PhysicalCarrier"@fr ;
-        sh:severity sh:Violation ;
-  ] .
-
+    ] .


### PR DESCRIPTION
A previous commit ([PR](https://github.com/viaacode/datamodels/pull/88)) removed the maxCount on storedAt on PhysicalCarrier. That made the constraint being removed here redundant.