### PR TITLE
Change coloringType to `0..*`

### DIFF
--- a/description/film.shacl.ttl
+++ b/description/film.shacl.ttl
@@ -77,7 +77,6 @@
         sh:class skos:Concept ;
         sh:in (haCt:BandW haCt:Color haCt:Colorized haCt:Composite haCt:Tinted haCt:Toned haCt:UnknownColorType) ;
         sh:minCount 0 ;
-        sh:maxCount 1 ;
         sh:name "coloring type"@en ;
         sh:name "type de coloration"@fr ;
         sh:name "type kleuring"@nl ;


### PR DESCRIPTION
An ImageReel can have multiple coloring types in the KG ETL ([example](https://github.com/viaacode/prefect-flow-object-etl/blob/f08c16f974fa03ad2c84a344061f91f50a3befe4/triplyetl/src/objects/film/AudioImageReel.ts#L35)).