### PR TITLE
Add alternate name creative work and broadcast event

### DIFF
--- a/description/description.shacl.ttl
+++ b/description/description.shacl.ttl
@@ -818,7 +818,7 @@
 ####################
 <#CreativeWorkSeriesShape> a sh:NodeShape ; 
     sh:targetClass schema:CreativeWorkSeries ;
-    sh:property <#NameShape>, <#DescriptionShape>,
+    sh:property <#NameShape>, <#AlternateNameShape>, <#DescriptionShape>,
     [
         a sh:PropertyShape ;
         sh:path schema:identifier ;
@@ -878,7 +878,7 @@
 
 <#CreativeWorkSeasonShape> a sh:NodeShape ; 
     sh:targetClass schema:CreativeWorkSeason ;
-    sh:property <#NameShape>, <#DescriptionShape>,
+    sh:property <#NameShape>, <#AlternateNameShape>, <#DescriptionShape>,
     [
         a sh:PropertyShape ;
         sh:path schema:identifier ;
@@ -938,7 +938,7 @@
 
 <#EpisodeShape> a sh:NodeShape ; 
     sh:targetClass schema:Episode ;
-    sh:property <#IdentifierShape>, <#NameShape>, <#DescriptionShape> ,
+    sh:property <#IdentifierShape>, <#NameShape>, <#AlternateNameShape>, <#DescriptionShape> ,
     [
         a sh:PropertyShape ;
         sh:path schema:hasPart ;
@@ -977,7 +977,7 @@
 
 <#ArchiveComponentShape> a sh:NodeShape ; 
     sh:targetClass schema:ArchiveComponent ;
-    sh:property <#NameShape>, <#DescriptionShape>,
+    sh:property <#NameShape>, <#AlternateNameShape>, <#DescriptionShape>,
     [
         a sh:PropertyShape ;
         sh:path schema:hasPart ;
@@ -1513,6 +1513,18 @@
     sh:message "schema:name is missing or not of type string "@en ;
     sh:message "schema:name ontbreekt of is niet van het type string"@nl ;
     sh:message "schema:name est manquant ou n'est pas de type string"@fr .
+
+<#AlternateNameShape> a sh:PropertyShape ;
+    sh:path schema:alternateName ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype rdf:langString ;
+    sh:name "alternate name"@en ;
+    sh:name "alternatieve naam"@nl ;
+    sh:name "nom alternatif"@fr ;
+    sh:severity sh:Violation ;
+    sh:message "schema:alternateName is not of type string"@en ;
+    sh:message "schema:alternateName is niet van het type string"@nl ;
+    sh:message "schema:alternateName n'est pas de type string"@fr .
 
 <#DescriptionShape> a sh:PropertyShape ;
     sh:path schema:description ;

--- a/description/description.shacl.ttl
+++ b/description/description.shacl.ttl
@@ -955,6 +955,10 @@
         sh:message "schema:hasPart n'est pas de la classe premis:IntellectualEntity"@fr ;
     ] .
 
+<#BroadcastEvent> a sh:NodeShape ; 
+    sh:targetClass schema:BroadcastEvent ;
+    sh:property <#NameShape>, <#AlternateNameShape> , <#DescriptionShape> .
+
 <#PlaceShape> a sh:NodeShape ; 
     sh:targetClass schema:Place ;
     sh:property <#NameShape>, <#DescriptionShape>,


### PR DESCRIPTION
- Adds schema:alternateName to creative work subclasses
- Adds broadcast event SHACL

As mentioned in the [PR in the documentation](https://github.com/viaacode/documentation/pull/186) this is done because it is used in the export of the registration tool.