### PR TITLE
ARC-3536 Add VAT number

### DIFF
--- a/organizations/organizations.rdfs.ttl
+++ b/organizations/organizations.rdfs.ttl
@@ -162,3 +162,14 @@ haOrg:hasPreference a rdf:Property ;
     skos:definition "Expresses the wish of an organization regarding whether or not to perform a certain service in collaboration with/by meemoo."@en ;
     skos:definition "Exprime le souhait d'une organisation quant à la réalisation ou non d'un certain service en collaboration avec/par meemoo."@fr ;
     rdfs:isDefinedBy <https://data.hetarchief.be/ns/organization/> .
+
+schema:vatID a rdf:Property ;
+    rdfs:domain org:Organization ;
+    rdfs:range rdfs:Literal ;
+    rdfs:label "btw-nummer"@nl ;
+    rdfs:label "VAT number"@en ;
+    rdfs:label "numéro de TVA"@fr ;
+    skos:definition "Verwijst naar het btw-nummer van de organisatie."@nl ;
+    skos:definition "Indicates the VAT number of the organization."@en ;
+    skos:definition "Indique le numéro de TVA de l'organisation."@fr ;
+    rdfs:isDefinedBy <https://data.hetarchief.be/ns/organization/> .

--- a/organizations/organizations.shacl.ttl
+++ b/organizations/organizations.shacl.ttl
@@ -309,7 +309,26 @@
     sh:description "Verwijst naar de unieke identificator van de organisatie."@nl ;
 
     sh:message "occurs more than once or its object is no xsd:string"@en ;
-  ] .
+  ],
+  [
+    a sh:PropertyShape ;
+    sh:path schema:vatID ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype xsd:string ;
+
+    sh:name "btw-nummer"@nl ;
+    sh:name "VAT number"@en ;
+    sh:name "numéro de TVA"@fr ;
+    
+    sh:description "Indicates the VAT number of the organisation."@en ;
+    sh:description "Indique le numéro de TVA de l'organisation."@fr ;
+    sh:description "Verwijst naar het btw-nummer van de organisatie."@nl ;
+
+    sh:message "occurs more than once or its object is no xsd:string"@en ;
+  ]
+  .
 
 <#LogoShape> a sh:NodeShape ;
   sh:targetClass haOrg:Logo .


### PR DESCRIPTION
Adds the VAT number (btw-nummer). Based of `rov:registration` from https://www.w3.org/ns/regorg#registration.

Since `@prefix rov: <http://www.w3.org/ns/regorg#>.` isn't used anywhere yet in the datamodels I've added `registration` to our `haOrg` namespace. Is this ok or should I keep with `rov` and add it to the `external_ontologies/` and `ontologies/`?